### PR TITLE
Stylelint update

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,5 +1,8 @@
 {
 	"extends": [
 		"stylelint-config-wordpress/scss"
-	]
+	],
+	"rules": {
+		"no-descending-specificity": null
+	}
 }


### PR DESCRIPTION
Stylelint do not respect parents correctly and give false positive it check that `<li>` later in code have less specificity and throws error even when first block don't even target .woocommerce-checkout-payment li

```
Expected selector ".woocommerce-checkout-payment li" to come before selector ".woocommerce-checkout .shipping_details .woocommerce-shipping-totals li:last-child"
stylelint(no-descending-specificity)
```