### PR TITLE
Add ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store


### PR DESCRIPTION
When initializing the project and running the install all dependencies are installed in 'node_modules' folder and are tracked as active changes. As there's no need for them to be included in the project they should be ignored by defaut.