### PR TITLE
Add PHPCS to Gulp

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ assets
             **.js
 ```
 
+## Requirements
+
+These dependencies are required. Instructions for each dependency can be found on their website.
+
+- [PHP](http://php.net/) 7.0
+- [npm](https://www.npmjs.com/)
+- [Composer](https://getcomposer.org/) (installed globally)
+
 ## Install
 
 ### For only asset compilation
@@ -36,6 +44,10 @@ or
 or
 
 `yarn install`
+
+### Install dependencies
+
+`npm run init` to install all dependencies for Node and Composer.
 
 ## Usage
 
@@ -123,6 +135,12 @@ You can use the `--version` option to target a specific bump. You can use the fo
 - `x.x.x` to set a specific version number. Eg `--version=2.3.4`
 
 For details on which version to bump, read about [Semantic Versioning](https://semver.org/).
+
+### PHPCS
+
+`gulp phpcs`
+
+Will run `phpcs` script from PHP_CodeSniffer and output detected violations of defined coding standard.
 
 ## Configuration
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "saucal/project-gulp-boilerplate",
+    "description": "Project Description",
+    "type": "project",
+    "license": "ISC",
+    "require-dev": {
+        "php": ">=7.0",
+        "wp-coding-standards/wpcs": "^2",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4",
+        "phpcompatibility/php-compatibility": "^9"
+    },
+    "config": {
+      "platform": {
+        "php": "7.0"
+      }
+    }
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,10 +1,11 @@
-var $, _, gulp, merge, fs, path, semver, nodegit, CONFIG, FOLDERS, DOMAIN, PATHS, MATCH, SRC;
+var $, _, gulp, merge, fs, path, semver, nodegit, phpcs, CONFIG, FOLDERS, DOMAIN, PATHS, MATCH, SRC, rootPath, PHPCSConfig;
 
 gulp   = require( 'gulp' );
 merge  = require( 'merge-stream' );
 fs     = require( 'fs' );
 path   = require( 'path' );
 semver = require( 'semver' );
+phpcs  = require( 'gulp-phpcs' );
 _      = require( 'underscore' );
 $      = require( 'gulp-load-plugins' )( {pattern: '*'} );
 
@@ -46,6 +47,14 @@ SRC = {
 	sass: [],
 	js: []
 };
+
+rootPath = process.cwd();
+
+PHPCSConfig = {
+	bin: `${ rootPath }/vendor/bin/phpcs`,
+	standard: 'WordPress-Extra',
+	warningSeverity: 0,
+}
 
 /* Confing: Edit saucal.json to set your folders and domain
 ========================================================= */
@@ -370,6 +379,26 @@ gulp.task(
 		}
 		$.browserSync.init( files, {proxy: DOMAIN} );
 		return done();
+	}
+);
+
+gulp.task(
+	'phpcs',
+	function() {
+		var files = [];
+		FOLDERS.map(
+			function ( folderConfig ) {
+				files.push( path.join( folderConfig.folder, folderConfig.MATCH.php ) );
+				console.log( files );
+			}
+		);
+		return gulp.src( files )
+			.pipe( phpcs( {
+				bin: PHPCSConfig.bin,
+				standard: PHPCSConfig.standard,
+				warningSeverity: PHPCSConfig.warningSeverity
+			} ) )
+			.pipe( phpcs.reporter( 'log' ) );
 	}
 );
 

--- a/package.json
+++ b/package.json
@@ -39,9 +39,11 @@
     "underscore": "^1.9.1"
   },
   "devDependencies": {
+    "gulp-phpcs": "^3.1.0",
     "nodegit": "^0.24.1"
   },
   "scripts": {
+    "init": "npm install && composer install",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [


### PR DESCRIPTION
Add PHP_CodeSniffer as a Gulp task.
Added Composer dependencies.
Added documentation.

Need to discuss as a team some dependencies and configuration. Comments here by all team members would be nice:

-  PHP 7.0 as minimum requirement.
- WordPress-Extra as WordPress Standard.
