### PR TITLE
Add WordPress Scripts.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "version": "0.0.1",
   "main": "gulpfile.js",
   "dependencies": {
-    "@wordpress/eslint-plugin": "^3.3.0",
+    "@wordpress/scripts": "^7.0.1",
     "browser-sync": "^2.26.3",
-    "eslint": "^5.15.1",
     "gulp": ">=4.0.0",
     "gulp-add-src": "^1.0.0",
     "gulp-autoprefixer": ">=6.0.0",
@@ -34,15 +33,16 @@
     "merge-stream": "^1.0.1",
     "path": ">=0.12.7",
     "semver": "^6.0.0",
-    "stylelint": "^11.1.1",
-    "stylelint-config-wordpress": "^15.0.0",
     "underscore": "^1.9.1"
   },
   "devDependencies": {
     "nodegit": "^0.24.1"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "format:js": "wp-scripts format-js",
+    "lint:css": "wp-scripts lint-style",
+    "lint:js": "wp-scripts lint-js"
   },
   "keywords": [
     "wordpress",


### PR DESCRIPTION
- Add WordPress Scripts.
- Add npm scripts to run linters.
- Remove not needed eslint/stylelint/config dependencies (as they are included in WordPress Scripts package).