### PR TITLE
Feature/replace linters

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,6 +1,0 @@
-# Browsers that we support
-
-last 5 versions
-> 1%
-maintained node versions
-not dead

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,0 @@
-{
-	"extends": [ "plugin:@wordpress/eslint-plugin/es5" ],
-	"env": {
-	  "browser": true,
-	  "commonjs": true,
-	  "node": false
-	}
-  }

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,8 +1,0 @@
-{
-	"extends": [
-		"stylelint-config-wordpress/scss"
-	],
-	"rules": {
-		"no-descending-specificity": null
-	}
-}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,18 +47,18 @@ SRC = {
 	js: []
 };
 
-/* Config: Edit projectFolders entry into package.json to set your folders and domain
+/* Config: Edit project-folders.json or projectFolders entry into package.json to set your folders
 ========================================================= */
 try {
+	FOLDERS = JSON.parse( fs.readFileSync( './project-folders.json' ) );
+} catch ( e ) {
 	var pkgJson = JSON.parse( fs.readFileSync( './package.json' ) );
 
 	if ( "projectFolders" in pkgJson ) {
 		FOLDERS = pkgJson.projectFolders;
 	} else {
-		FOLDERS = JSON.parse( fs.readFileSync( './project-folders.json' ) );
+		FOLDERS = [ '.' ];
 	}
-} catch ( e ) {
-	FOLDERS = [ '.' ];
 }
 
 Array.prototype.getFiltered = function(type){

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,10 +49,14 @@ SRC = {
 
 /* Config: Edit projectFolders entry into package.json to set your folders and domain
 ========================================================= */
-var pkgJson = JSON.parse( fs.readFileSync( './package.json' ) );
-
 try {
-	FOLDERS = pkgJson.projectFolders;
+	var pkgJson = JSON.parse( fs.readFileSync( './package.json' ) );
+
+	if ( "projectFolders" in pkgJson ) {
+		FOLDERS = pkgJson.projectFolders;
+	} else {
+		FOLDERS = JSON.parse( fs.readFileSync( './project-folders.json' ) );
+	}
 } catch ( e ) {
 	FOLDERS = [ '.' ];
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,10 +47,12 @@ SRC = {
 	js: []
 };
 
-/* Confing: Edit saucal.json to set your folders and domain
+/* Config: Edit projectFolders entry into package.json to set your folders and domain
 ========================================================= */
+var pkgJson = JSON.parse( fs.readFileSync( './package.json' ) );
+
 try {
-	FOLDERS = JSON.parse( fs.readFileSync( './project-folders.json' ) );
+	FOLDERS = pkgJson.projectFolders;
 } catch ( e ) {
 	FOLDERS = [ '.' ];
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@wordpress/eslint-plugin": "^4.1.0",
     "@wordpress/scripts": "^7.2.0",
     "browser-sync": "^2.26.3",
-    "eslint": "^5.15.1",
     "gulp": ">=4.0.0",
     "gulp-add-src": "^1.0.0",
     "gulp-autoprefixer": ">=6.0.0",

--- a/package.json
+++ b/package.json
@@ -75,5 +75,9 @@
     "wordpress plugin"
   ],
   "author": "SAU/CAL",
-  "license": "ISC"
+  "license": "ISC",
+  "projectFolders": [
+    "wp-content/plugins/project-plugin",
+    "wp-content/themes/project-theme"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -38,10 +38,12 @@
     "underscore": "^1.9.1"
   },
   "devDependencies": {
-    "nodegit": "^0.24.1"
+    "nodegit": "^0.26.5"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "lint:css": "wp-scripts lint-style",
+    "lint:js": "wp-scripts lint-js",
+    "format:js": "wp-scripts format-js"
   },
   "browserslist": [
     "last 5 versions",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.1",
   "main": "gulpfile.js",
   "dependencies": {
-    "@wordpress/eslint-plugin": "^3.3.0",
+    "@wordpress/eslint-plugin": "^4.1.0",
+    "@wordpress/scripts": "^7.2.0",
     "browser-sync": "^2.26.3",
     "eslint": "^5.15.1",
     "gulp": ">=4.0.0",
@@ -34,8 +35,6 @@
     "merge-stream": "^1.0.1",
     "path": ">=0.12.7",
     "semver": "^6.0.0",
-    "stylelint": "^11.1.1",
-    "stylelint-config-wordpress": "^15.0.0",
     "underscore": "^1.9.1"
   },
   "devDependencies": {
@@ -43,6 +42,30 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "browserslist": [
+    "last 5 versions",
+    "> 1%",
+    "maintained node versions",
+    "not dead"
+  ],
+  "eslintConfig": {
+    "extends": [
+      "plugin:@wordpress/eslint-plugin/es5"
+    ],
+    "env": {
+      "browser": true,
+      "commonjs": true,
+      "node": false
+    }
+  },
+  "stylelint": {
+    "extends": [
+      "stylelint-config-wordpress/scss"
+    ],
+    "rules": {
+      "no-descending-specificity": null
+    }
   },
   "keywords": [
     "wordpress",

--- a/project-folders.json
+++ b/project-folders.json
@@ -1,4 +1,0 @@
-[
-    "wp-content/plugins/project-plugin",
-    "wp-content/themes/project-theme"
-]


### PR DESCRIPTION
Key changes:
- Make use @wordpress linter modules as they are already configured to properly work in WP-related projects (also, custom npm scripts were added to help on that work. Eg. npm run lint:css)
- Reduce the amount of development-related files from the project folder by moving settings to package.json